### PR TITLE
ENH: Added a parameter to perform blind analysis

### DIFF
--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -143,7 +143,7 @@ class WeightedSamples(object):
     """
 
     def __init__(self, filename=None, ignore_rows=0, samples=None, weights=None, loglikes=None, name_tag=None,
-                 files_are_chains=True, blind=True):
+                 files_are_chains=True, blind=False):
         """
         :param filename: A filename of a plain text file to load from
         :param ignore_rows: 
@@ -790,7 +790,7 @@ class Chains(WeightedSamples):
     :ivar paramNames: a :class:`~.paramnames.ParamNames` instance holding the parameter names and labels
     """
 
-    def __init__(self, root=None, jobItem=None, paramNamesFile=None, names=None, labels=None, blind=True, **kwargs):
+    def __init__(self, root=None, jobItem=None, paramNamesFile=None, names=None, labels=None, blind=False, **kwargs):
         """
 
         :param root: optional root name for files

--- a/getdist/mcsamples.py
+++ b/getdist/mcsamples.py
@@ -43,7 +43,7 @@ class ParamError(MCSamplesError):
     pass
 
 
-def loadMCSamples(file_root, ini=None, jobItem=None, no_cache=False, settings={}, dist_settings={}, blind=True):
+def loadMCSamples(file_root, ini=None, jobItem=None, no_cache=False, settings={}, dist_settings={}, blind=False):
     """
     Loads a set of samples from a file or files.
     
@@ -112,7 +112,7 @@ class MCSamples(Chains):
     Derives from :class:`.chains.Chains`, adding high-level functions including Kernel Density estimates, parameter ranges and custom settings.
     """
 
-    def __init__(self, root=None, jobItem=None, ini=None, settings=None, ranges=None, blind=True, **kwargs):
+    def __init__(self, root=None, jobItem=None, ini=None, settings=None, ranges=None, blind=False, **kwargs):
         """        
         For a description of the various analysis settings and default values see
         `analysis_defaults.ini <http://getdist.readthedocs.org/en/latest/analysis_settings.html>`_.

--- a/getdist/plots.py
+++ b/getdist/plots.py
@@ -258,7 +258,8 @@ def getSubplotPlotter(subplot_size=2, width_inch=None, **kwargs):
 
 class SampleAnalysisGetDist(object):
     # Old class to support pre-computed GetDist plot_data output
-    def __init__(self, plot_data):
+    def __init__(self, plot_data, blind=True):
+        raise ValueError("Old pre-computed GetDist plot_data output does not support the blind option\n")
         self.plot_data = plot_data
         self.newPlot()
         self.paths = dict()
@@ -362,7 +363,7 @@ class MCSampleAnalysis(object):
     get an :class:`~.mcsamples.MCSamples` instance from a root name being used by a plotter, use plotter.sampleAnalyser.samplesForRoot(name).
     """
 
-    def __init__(self, chain_locations, settings=None):
+    def __init__(self, chain_locations, settings=None, blind=True):
         """
         :param chain_locations: either a directory or the path of a grid of runs;
                it can also be a list of such, which is searched in order
@@ -372,6 +373,7 @@ class MCSampleAnalysis(object):
         self.chain_dirs = []
         self.chain_locations = []
         self.ini = None
+        self.blind = blind
         if chain_locations is not None:
             if isinstance(chain_locations, six.string_types):
                 chain_locations = [chain_locations]
@@ -461,7 +463,7 @@ class MCSampleAnalysis(object):
         if not file_root:
             raise GetDistPlotError('chain not found: ' + root)
 
-        self.mcsamples[root] = loadMCSamples(file_root, self.ini, jobItem, settings=dist_settings)
+        self.mcsamples[root] = loadMCSamples(file_root, self.ini, jobItem, settings=dist_settings, blind=self.blind)
         return self.mcsamples[root]
 
     def addRoots(self, roots):
@@ -599,7 +601,7 @@ class GetDistPlotter(object):
          and derived data from a given root name tag (e.g. sampleAnalyser.samplesForRoot('rootname'))
     """
 
-    def __init__(self, plot_data=None, chain_dir=None, settings=None, analysis_settings=None, mcsamples=True):
+    def __init__(self, plot_data=None, chain_dir=None, settings=None, analysis_settings=None, mcsamples=True, blind=True):
         """
         
         :param plot_data: (deprecated) directory name if you have pre-computed plot_data/ directory from GetDist; None by default
@@ -618,9 +620,9 @@ class GetDistPlotter(object):
         else:
             self.plot_data = plot_data
         if chain_dir is not None or mcsamples and plot_data is None:
-            self.sampleAnalyser = MCSampleAnalysis(chain_dir, analysis_settings)
+            self.sampleAnalyser = MCSampleAnalysis(chain_dir, analysis_settings, blind=blind)
         else:
-            self.sampleAnalyser = SampleAnalysisGetDist(self.plot_data)
+            self.sampleAnalyser = SampleAnalysisGetDist(self.plot_data, blind=blind)
         self.newPlot()
 
     def newPlot(self):

--- a/getdist/plots.py
+++ b/getdist/plots.py
@@ -258,8 +258,8 @@ def getSubplotPlotter(subplot_size=2, width_inch=None, **kwargs):
 
 class SampleAnalysisGetDist(object):
     # Old class to support pre-computed GetDist plot_data output
-    def __init__(self, plot_data, blind=True):
-        raise ValueError("Old pre-computed GetDist plot_data output does not support the blind option\n")
+    def __init__(self, plot_data, blind=False):
+        warnings.warn("Old pre-computed GetDist plot_data output does not support the blind option\n")
         self.plot_data = plot_data
         self.newPlot()
         self.paths = dict()
@@ -363,7 +363,7 @@ class MCSampleAnalysis(object):
     get an :class:`~.mcsamples.MCSamples` instance from a root name being used by a plotter, use plotter.sampleAnalyser.samplesForRoot(name).
     """
 
-    def __init__(self, chain_locations, settings=None, blind=True):
+    def __init__(self, chain_locations, settings=None, blind=False):
         """
         :param chain_locations: either a directory or the path of a grid of runs;
                it can also be a list of such, which is searched in order
@@ -601,7 +601,7 @@ class GetDistPlotter(object):
          and derived data from a given root name tag (e.g. sampleAnalyser.samplesForRoot('rootname'))
     """
 
-    def __init__(self, plot_data=None, chain_dir=None, settings=None, analysis_settings=None, mcsamples=True, blind=True):
+    def __init__(self, plot_data=None, chain_dir=None, settings=None, analysis_settings=None, mcsamples=True, blind=False):
         """
         
         :param plot_data: (deprecated) directory name if you have pre-computed plot_data/ directory from GetDist; None by default


### PR DESCRIPTION
I wanted to add an enhancement to getdist where the chains could be analyzed in a blinded manner. These changes add a default parameter blind which shifts the parameter values by their means. The default option is currently set to True, so that performing blind analyses require you to manually specify blind=False.

It would be great if you could perform a code review, to catch things that I may have missed and which are commonly used to analyze chains by COSMOMC users, and eventually merge this in case you find this enhancement useful.