### PR TITLE
Minor fix, in case scientific notation is needed

### DIFF
--- a/getdist/plots.py
+++ b/getdist/plots.py
@@ -1287,7 +1287,8 @@ class GetDistPlotter(object):
         :param x: True if x axis, False for y axis
         :param prune: Parameter for MaxNLocator constructor, ,  ['lower' | 'upper' | 'both' | None]
         """
-        formatter = matplotlib.ticker.ScalarFormatter(useOffset=False)
+        formatter = matplotlib.ticker.ScalarFormatter(useOffset=False, useMathText=True)
+        formatter.set_powerlimits((-3,3))
         axis.set_major_formatter(formatter)
         plt.tick_params(axis='both', which='major', labelsize=self.settings.axes_fontsize)
         if x and self.settings.x_label_rotation != 0: plt.setp(plt.xticks()[1], rotation=self.settings.x_label_rotation)

--- a/getdist/plots.py
+++ b/getdist/plots.py
@@ -1287,9 +1287,15 @@ class GetDistPlotter(object):
         :param x: True if x axis, False for y axis
         :param prune: Parameter for MaxNLocator constructor, ,  ['lower' | 'upper' | 'both' | None]
         """
-        formatter = matplotlib.ticker.ScalarFormatter(useOffset=False, useMathText=True)
-        formatter.set_powerlimits((-3,3))
-        axis.set_major_formatter(formatter)
+        sFormatter = matplotlib.ticker.ScalarFormatter(useOffset=False, useMathText=True)
+        sFormatter.set_powerlimits((-3,3))
+        if isinstance(axis, matplotlib.axis.XAxis):
+            axis.set_major_formatter(sFormatter)
+        else:
+            # from https://stackoverflow.com/questions/25750170
+            sci_func = (lambda x, pos:
+                        "${}$".format(sFormatter._formatSciNotation('%.10g' % x)))
+            axis.set_major_formatter(matplotlib.ticker.FuncFormatter(sci_func))
         plt.tick_params(axis='both', which='major', labelsize=self.settings.axes_fontsize)
         if x and self.settings.x_label_rotation != 0: plt.setp(plt.xticks()[1], rotation=self.settings.x_label_rotation)
         self._set_locator(axis, x, prune=prune)


### PR DESCRIPTION
TeX'ing ticks labels. Only affects cases that need scientific notation (controlled by the min and max exponents in ``formatter.set_powerlimits((min,max))``).

Unfortunately, there is still a problem with those cases: the offset/multiplier in the y-axis overlaps with the plot on top in triangle plots, and its position cannot be changed (it's a known shortcoming: https://github.com/matplotlib/matplotlib/issues/4476).

**EDIT:** Solved by treating x and y ticks differently (see attached plot)
![test](https://user-images.githubusercontent.com/2233649/45439918-5837ed80-b6bb-11e8-89e5-2c05284842be.png)

**EDIT:** I just noticed that it breaks consistency in the number of decimal places in they y axis. Looking into it...