### PR TITLE
Storing sampler type and treat Nested Sampler samples correctly (issue #27)

### DIFF
--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -862,7 +862,7 @@ class Chains(WeightedSamples):
         # Sampler that generated the chain -- assume "mcmc"
         if isinstance(sampler, six.string_types) and sampler.lower() in ["mcmc", "nested", "uncorrelated"]:
             self.sampler = sampler.lower()
-        elif isinstance(ParamNamesFile, six.string_types) and ParamNamesFile.endswith("yaml"):
+        elif isinstance(paramNamesFile, six.string_types) and paramNamesFile.endswith("yaml"):
             self.sampler = get_sampler_type(paramNamesFile)
         else:
             self.sampler = "mcmc"

--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -862,7 +862,7 @@ class Chains(WeightedSamples):
         # Sampler that generated the chain -- assume "mcmc"
         if isinstance(sampler, six.string_types) and sampler.lower() in ["mcmc", "nested", "uncorrelated"]:
             self.sampler = sampler.lower()
-        elif (paramNamesFile or "").endswith("yaml"):
+        elif isinstance(ParamNamesFile, six.string_types) and ParamNamesFile.endswith("yaml"):
             self.sampler = get_sampler_type(paramNamesFile)
         else:
             self.sampler = "mcmc"

--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -4,6 +4,7 @@ import random
 import numpy as np
 from getdist.paramnames import ParamNames, ParamInfo, escapeLatex
 from getdist.convolve import autoConvolve
+from getdist.yaml_format_tools import get_sampler_type
 import pickle
 import six
 
@@ -830,7 +831,7 @@ class Chains(WeightedSamples):
     :ivar paramNames: a :class:`~.paramnames.ParamNames` instance holding the parameter names and labels
     """
 
-    def __init__(self, root=None, jobItem=None, paramNamesFile=None, names=None, labels=None, renames=None, **kwargs):
+    def __init__(self, root=None, jobItem=None, paramNamesFile=None, names=None, labels=None, renames=None, sampler=None, **kwargs):
         """
 
         :param root: optional root name for files
@@ -858,6 +859,13 @@ class Chains(WeightedSamples):
             self.paramNames.setLabels(labels)
         if renames is not None:
             self.updateRenames(renames)
+        # Sampler that generated the chain -- assume "mcmc"
+        if isinstance(sampler, six.string_types) and sampler.lower() in ["mcmc", "nested", "uncorrelated"]:
+            self.sampler = sampler.lower()
+        elif (paramNamesFile or "").endswith("yaml"):
+            self.sampler = get_sampler_type(paramNamesFile)
+        else:
+            self.sampler = "mcmc"
 
     def setParamNames(self, names=None):
         """

--- a/getdist/yaml_format_tools.py
+++ b/getdist/yaml_format_tools.py
@@ -14,6 +14,7 @@ _prior = "prior"
 _theory = "theory"
 _params = "params"
 _likelihood = "likelihood"
+_sampler = "sampler"
 _p_label = "latex"
 _p_dist = "dist"
 _p_value = "value"
@@ -182,3 +183,11 @@ def expand_info_param(info_param):
     if isinstance(value, string_types) or callable(value):
         info_param[_p_derived] = info_param.get(_p_derived, True)
     return info_param
+
+
+def get_sampler_type(filename_or_info):
+    if isinstance(filename_or_info, string_types):
+        filename_or_info = yaml_load_file(filename_or_info)
+    default_sampler_for_chain_type = "mcmc"
+    sampler = list(filename_or_info.get(_sampler, [default_sampler_for_chain_type]))[0]
+    return {"mcmc": "mcmc", "polychord": "nested"}[sampler]


### PR DESCRIPTION
Hi @cmbant and @williamjameshandley,

Here is the first step of what I was proposing re #27: store the sampler type as an attribute of `MCSamples`. If @cmbant likes the idea and the way/places the changes have been introduced, I'll try yo do step 2: shuffle the samples before calling `MCSamples.updateBaseStatistics()`.

Cheers!