### PR TITLE
doc: correct doc string for MCSamples.getRenames

### DIFF
--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -938,7 +938,7 @@ class Chains(WeightedSamples):
 
     def getRenames(self):
         """
-        Updates the renames known to each parameter with the given dictionary of renames.
+        Gets dictionary of renames known to each parameter.
         """
         return self.paramNames.getRenames()
 


### PR DESCRIPTION
`getdist.mcsamples.MCSamples.getRenames` had the same doc string as
`getdist.mcsamples.MCSamples.updateRenames`.  Change it to be the same
as that for `getdist.paramnames.getRenames`.