### PR TITLE
Small fix

### DIFF
--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -761,6 +761,8 @@ class WeightedSamples:
         if isinstance(pars, _int_types) and pars >= 0 and where is None:
             means = self.getMeans()
             return [self.samples[:, i] - means[i] for i in range(pars)]
+        elif isinstance(pars, _int_types) and pars >= 0 and where is not None:
+            return [self.mean_diff(i, where) for i in range(pars)]
         else:
             return [self.mean_diff(i, where) for i in pars]
 


### PR DESCRIPTION
Had a problem when using mean_diffs with the argument where but no parameter specified.
If where is specified but pars is not then the original code tries to iterate over an int and crashes.