### PR TITLE
[WIP] Cobaya tempered chains

### DIFF
--- a/getdist/cobaya_interface.py
+++ b/getdist/cobaya_interface.py
@@ -106,22 +106,19 @@ def MCSamplesFromCobaya(info, collections, name_tag=None,
     weights = [c[_weight].values.astype(np.float64) for c in collections]
     loglikes = [c[_minuslogpost].values.astype(np.float64) for c in collections]
     sampler = get_sampler_type(info)
+    temperature = get_sampler_temperature(info)
     label = get_sample_label(info)
-    temperature = getattr(collections[0], "temperature", 1)
     if temperature != 1:
         logging.warning("You have loaded a sample with non-unit temperature. "
                         "Use the 'MCSamples.cool()' method to turn it into a sample from "
                         "the original posterior before performing statistical analyses, "
                         "but maybe after thinning the sample with method "
                         "'MCSamples.thin_indices()'.")
-    inferred_settings = {"temperature": temperature}
-    if settings is not None:
-        inferred_settings.update(settings)
     from getdist.mcsamples import MCSamples
     return MCSamples(samples=samples, weights=weights, loglikes=loglikes, sampler=sampler,
                      names=names, labels=labels, ranges=ranges, renames=renames,
                      ignore_rows=ignore_rows, name_tag=name_tag, label=label, ini=ini,
-                     settings=inferred_settings)
+                     temperature=temperature, settings=settings)
 
 
 def str_to_list(x):
@@ -260,10 +257,19 @@ def expand_info_param(info_param):
     return info_param
 
 
-def get_sampler_type(filename_or_info, default_sampler_for_chain_type="mcmc"):
-    sampler = list(yaml_file_or_dict(filename_or_info).get(_sampler, [
+def get_sampler_key(filename_or_info, default_sampler_for_chain_type="mcmc"):
+    return list(yaml_file_or_dict(filename_or_info).get(_sampler, [
         default_sampler_for_chain_type]))[0]
+
+
+def get_sampler_type(filename_or_info, default_sampler_for_chain_type="mcmc"):
+    sampler = get_sampler_key(filename_or_info, default_sampler_for_chain_type)
     return {"mcmc": "mcmc", "polychord": "nested", "minimize": "minimize"}[sampler]
+
+
+def get_sampler_temperature(filename_or_info):
+    sampler = get_sampler_key(filename_or_info)
+    return yaml_file_or_dict(filename_or_info)["sampler"][sampler].get("temperature")
 
 
 def get_sample_label(filename_or_info):

--- a/getdist/cobaya_interface.py
+++ b/getdist/cobaya_interface.py
@@ -107,11 +107,21 @@ def MCSamplesFromCobaya(info, collections, name_tag=None,
     loglikes = [c[_minuslogpost].values.astype(np.float64) for c in collections]
     sampler = get_sampler_type(info)
     label = get_sample_label(info)
+    temperature = getattr(collections[0], "temperature", 1)
+    if temperature != 1:
+        logging.warning("You have loaded a sample with non-unit temperature. "
+                        "Use the 'MCSamples.cool()' method to turn it into a sample from "
+                        "the original posterior before performing statistical analyses, "
+                        "but maybe after thinning the sample with method "
+                        "'MCSamples.thin_indices()'.")
+    inferred_settings = {"temperature": temperature}
+    if settings is not None:
+        inferred_settings.update(settings)
     from getdist.mcsamples import MCSamples
     return MCSamples(samples=samples, weights=weights, loglikes=loglikes, sampler=sampler,
                      names=names, labels=labels, ranges=ranges, renames=renames,
                      ignore_rows=ignore_rows, name_tag=name_tag, label=label, ini=ini,
-                     settings=settings)
+                     settings=inferred_settings)
 
 
 def str_to_list(x):

--- a/getdist/mcsamples.py
+++ b/getdist/mcsamples.py
@@ -488,6 +488,26 @@ class MCSamples(Chains):
 
         return self
 
+    def cool(self, cool=None):
+        """
+        Cools the samples, i.e. multiples log likelihoods by cool factor and re-weights accordingly
+        :param cool: cool factor, optional if the sample has a temperature specified.
+        """
+        if cool is None:
+            if self.properties.hasKey('temperature'):
+                cool = self.properties.float('temperature')
+            else:
+                raise ValueError(
+                    "Pass a cooling temperature, since the sample does not have one specified")
+        if cool == 1:
+            return
+        if self.properties.float('cooled', 1) != 1:
+            logging.warning('Chain has already been cooled by %s', self.properties.float('cooled'))
+        super().cool(cool)
+        self.properties.params['cooled'] = cool
+        if self.properties.hasKey('temperature'):
+            self.properties.params['temperature'] = self.properties.float('temperature') / cool
+
     def updateBaseStatistics(self):
         """
         Updates basic computed statistics (y, covariance etc.), e.g. after a change in samples or weights

--- a/getdist/mcsamples.py
+++ b/getdist/mcsamples.py
@@ -130,7 +130,8 @@ class MCSamples(Chains):
                  settings: Optional[Mapping[str, Any]] = None, ranges=None,
                  samples: Union[np.ndarray, Iterable[np.ndarray], None] = None,
                  weights: Union[np.ndarray, Iterable[np.ndarray], None] = None,
-                 loglikes: Union[np.ndarray, Iterable[np.ndarray], None] = None, **kwargs):
+                 loglikes: Union[np.ndarray, Iterable[np.ndarray], None] = None,
+                 temperature: Optional[float] = None, **kwargs):
         """
         For a description of the various analysis settings and default values see
         `analysis_defaults.ini <https://getdist.readthedocs.io/en/latest/analysis_settings.html>`_.
@@ -146,6 +147,8 @@ class MCSamples(Chains):
                         to :meth:`setSamples`, or list of arrays if more than one chain
         :param weights: array of weights for samples, or list of arrays if more than one chain
         :param loglikes: array of -log(Likelihood) for samples, or list of arrays if more than one chain
+        :param temperatute: temperature of the sample. If not specified will be read from the
+                            root.properties.ini file if it exists and otherwise default to 1.
         :param kwargs: keyword arguments passed to inherited classes, e.g. to manually make a samples object from
                        sample arrays in memory:
 
@@ -263,6 +266,10 @@ class MCSamples(Chains):
                 if 'sampler' not in kwargs:
                     self.setSampler(cobaya_interface.get_sampler_type(self.paramNames.info_dict))
                 self.properties.params['sampler'] = self.sampler
+                if temperature is None:
+                    temperature = cobaya_interface.get_sampler_temperature(self.paramNames.info_dict)
+            if temperature is not None and temperature != 1:
+                self.properties.params['temperature'] = temperature
         if self.ignore_frac or self.ignore_rows:
             self.properties.params['burn_removed'] = True
 

--- a/getdist/mcsamples.py
+++ b/getdist/mcsamples.py
@@ -177,7 +177,7 @@ class MCSamples(Chains):
             self.batch_path = ''
 
         self._readRanges()
-        if ranges:
+        if ranges is not None:
             self.setRanges(ranges)
 
         # Other variables
@@ -293,6 +293,9 @@ class MCSamples(Chains):
         :param ranges: A list or a tuple of [min,max] values for each parameter,
                        or a dictionary giving [min,max] values for specific parameter names
         """
+        if isinstance(ranges, np.ndarray):
+            if len(ranges.shape) == 2 and ranges.shape[1] == 2:
+                ranges = ranges.tolist()
         if isinstance(ranges, (list, tuple)):
             for i, minmax in enumerate(ranges):
                 self.ranges.setRange(self.parName(i), minmax)


### PR DESCRIPTION
Tries to interface Cobaya samples' temperature, so that one can cool without specifying a temperature, using instead the one read off the Cobaya Collection. Re-implements the cooling method wrapper of MCSamples from the [autocool](https://github.com/cmbant/getdist/tree/autocool) branch.

It also allows for passing a properly-shaped 2d numpy array as ranges, instead of a list/dict/etc.

TODO: I cannot get the temperature to propagate between here https://github.com/JesusTorrado/getdist/blob/49573b474ff88c1a9726637e5c9f7282fc90b51f/getdist/cobaya_interface.py#L110 and here https://github.com/JesusTorrado/getdist/blob/49573b474ff88c1a9726637e5c9f7282fc90b51f/getdist/mcsamples.py#L498