### PR TITLE
Make deleteFixedParams remove columns that are all NaN

### DIFF
--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -1037,9 +1037,11 @@ class WeightedSamples:
         fixed = []
         values = []
         for i in range(self.samples.shape[1]):
-            if np.isclose(self.samples[0, i], self.samples[-1, i]):
+            if np.isclose(self.samples[0, i], self.samples[-1, i]) or (
+                np.isnan(self.samples[0, i]) and np.isnan(self.samples[-1, i])
+            ):
                 mean = np.average(self.samples[:, i])
-                if np.allclose(self.samples[:, i], mean, rtol=1e-12, atol=0):
+                if np.allclose(self.samples[:, i], mean, rtol=1e-12, atol=0) or np.isnan(self.samples[:, i]).all():
                     fixed.append(i)
                     values.append(mean)
         self.changeSamples(np.delete(self.samples, fixed, 1))

--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -1030,7 +1030,8 @@ class WeightedSamples:
 
     def deleteFixedParams(self):
         """
-        Removes parameters that do not vary (are the same in all samples)
+        Removes parameters that do not vary (are the same in all samples).
+        This includes parameters that are all NaN.
 
         :return: tuple (list of fixed parameter indices that were removed, fixed values)
         """
@@ -1546,7 +1547,8 @@ class Chains(WeightedSamples):
 
     def deleteFixedParams(self):
         """
-        Delete parameters that are fixed (the same value in all samples)
+        Delete parameters that are fixed (the same value in all samples).
+        This includes parameters that are all NaN.
         """
         if self.samples is not None:
             fixed, values = super().deleteFixedParams()

--- a/getdist/chains.py
+++ b/getdist/chains.py
@@ -1038,11 +1038,9 @@ class WeightedSamples:
         fixed = []
         values = []
         for i in range(self.samples.shape[1]):
-            if np.isclose(self.samples[0, i], self.samples[-1, i]) or (
-                np.isnan(self.samples[0, i]) and np.isnan(self.samples[-1, i])
-            ):
+            if np.isclose(self.samples[0, i], self.samples[-1, i], equal_nan=True):
                 mean = np.average(self.samples[:, i])
-                if np.allclose(self.samples[:, i], mean, rtol=1e-12, atol=0) or np.isnan(self.samples[:, i]).all():
+                if np.allclose(self.samples[:, i], mean, rtol=1e-12, atol=0, equal_nan=True):
                     fixed.append(i)
                     values.append(mean)
         self.changeSamples(np.delete(self.samples, fixed, 1))


### PR DESCRIPTION
The deleteFixedParams method on WeightedSamples and its descendents does not currently remove entirely NaN columns because NaN is not close to NaN so the test does not detect it. This change adds a specific check for these columns.

I think it makes sense to remove such columns - they break similar things to constant columns later when plotting, for example.

The immediate use case for this is cosmosis chains, where nan columns can arise when derived parameters are not computed, but I guess there may be other similar cases from other sampling tools.  I could also put these checks inside the cosmosis code that generates MCSamples objects, if you prefer not to include it here.